### PR TITLE
[BUGFIX] add missing inject_params in summary.py and submit_wrapper.sh

### DIFF
--- a/scripts/submit_wrapper.sh
+++ b/scripts/submit_wrapper.sh
@@ -112,7 +112,7 @@ else
               "Any GPU aware:      ${ANY_GPU_AWARE}"
     fi
 
-    SLURM_PARAMS=" --account $PICO_ACCOUNT --nodes $N_NODES --time $TEST_TIME --partition $PARTITION"
+    SLURM_PARAMS=" --account $PICO_ACCOUNT --nodes $N_NODES --time $TEST_TIME --partition $PARTITION $INJECT_PARAMS"
 
     if [[ -n "$QOS" ]]; then
         SLURM_PARAMS+=" --qos $QOS"

--- a/tui/tui/steps/summary.py
+++ b/tui/tui/steps/summary.py
@@ -173,6 +173,11 @@ def json_to_exports(config: JsonLike, sh_path: Union[str, Path]) -> str:
         else:
             lines.append("# skipped: test.test_time missing")
 
+        if "inject_params" in test:
+            write_export("INJECT_PARAMS", test["inject_params"], quote=True)
+        else:
+            lines.append("# skipped: test.inject_params missing")
+
         # dimensions
         dims = test.get("dimensions")
         if not isinstance(dims, dict):


### PR DESCRIPTION
Hello !

Using `tui/main.py`, the feature that allows to inject parameters is ignored by the json to sh exporter and the submission wrapper.

This simple PR should fix the issue.

Regards
